### PR TITLE
Add EitherT and ResultT transformers

### DIFF
--- a/darkcore/__init__.py
+++ b/darkcore/__init__.py
@@ -8,9 +8,11 @@ from .maybe_t import MaybeT
 from .reader_t import ReaderT
 from .state_t import StateT
 from .writer_t import WriterT
+from .either_t import EitherT
+from .result_t import ResultT
 
 __all__ = [
     "Maybe", "Ok", "Err", "Left", "Right",
     "Reader", "Writer", "State",
-    "MaybeT", "ReaderT", "StateT", "WriterT"
+    "MaybeT", "ReaderT", "StateT", "WriterT", "EitherT", "ResultT"
 ]

--- a/darkcore/either_t.py
+++ b/darkcore/either_t.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+from typing import Callable, Generic, TypeVar, Any
+from .core import Monad as MonadLike
+from .either import Either, Left, Right
+
+A = TypeVar("A")
+B = TypeVar("B")
+
+class EitherT(Generic[A]):
+    """Monad transformer for Either.
+
+    Wraps: m (Either a)
+    """
+
+    def __init__(self, run: MonadLike[Any]) -> None:
+        self.run: MonadLike[Any] = run
+
+    @classmethod
+    def lift(cls, monad: MonadLike[A]) -> "EitherT[A]":
+        """Lift a monad into EitherT."""
+        return EitherT(monad.bind(lambda x: monad.pure(Right(x))))  # type: ignore[arg-type]
+
+    def map(self, f: Callable[[A], B]) -> "EitherT[B]":
+        return EitherT(self.run.bind(lambda e: self.run.pure(e.fmap(f))))
+
+    def ap(self: "EitherT[Callable[[A], B]]", fa: "EitherT[A]") -> "EitherT[B]":
+        return EitherT(self.run.bind(lambda mf: fa.run.bind(lambda mx: self.run.pure(mf.ap(mx)))))
+
+    def bind(self, f: Callable[[A], "EitherT[B]"]) -> "EitherT[B]":
+        def step(either: Either[A]) -> MonadLike[Any]:
+            if isinstance(either, Left):
+                return self.run.pure(either)
+            else:
+                return f(either.value).run
+        return EitherT(self.run.bind(step))
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, EitherT) and self.run == other.run
+
+    def __repr__(self) -> str:
+        return f"EitherT({self.run!r})"

--- a/darkcore/either_t.py
+++ b/darkcore/either_t.py
@@ -30,8 +30,10 @@ class EitherT(Generic[A]):
         def step(either: Either[A]) -> MonadLike[Any]:
             if isinstance(either, Left):
                 return self.run.pure(either)
-            else:
+            if isinstance(either, Right):
                 return f(either.value).run
+            # This branch is theoretically unreachable but keeps mypy satisfied
+            raise TypeError("Unexpected Either subtype")
         return EitherT(self.run.bind(step))
 
     def __eq__(self, other: object) -> bool:

--- a/darkcore/result_t.py
+++ b/darkcore/result_t.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+from typing import Callable, Generic, TypeVar, Any
+from .core import Monad as MonadLike
+from .result import Result, Ok, Err
+
+A = TypeVar("A")
+B = TypeVar("B")
+
+class ResultT(Generic[A]):
+    """Monad transformer for Result.
+
+    Wraps: m (Result a)
+    """
+
+    def __init__(self, run: MonadLike[Any]) -> None:
+        self.run: MonadLike[Any] = run
+
+    @classmethod
+    def lift(cls, monad: MonadLike[A]) -> "ResultT[A]":
+        """Lift a monad into ResultT."""
+        return ResultT(monad.bind(lambda x: monad.pure(Ok(x))))  # type: ignore[arg-type]
+
+    def map(self, f: Callable[[A], B]) -> "ResultT[B]":
+        return ResultT(self.run.bind(lambda r: self.run.pure(r.fmap(f))))
+
+    def ap(self: "ResultT[Callable[[A], B]]", fa: "ResultT[A]") -> "ResultT[B]":
+        return ResultT(self.run.bind(lambda mf: fa.run.bind(lambda mx: self.run.pure(mf.ap(mx)))))
+
+    def bind(self, f: Callable[[A], "ResultT[B]"]) -> "ResultT[B]":
+        def step(result: Result[A]) -> MonadLike[Any]:
+            if isinstance(result, Err):
+                return self.run.pure(result)
+            else:
+                return f(result.value).run
+        return ResultT(self.run.bind(step))
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, ResultT) and self.run == other.run
+
+    def __repr__(self) -> str:
+        return f"ResultT({self.run!r})"

--- a/darkcore/result_t.py
+++ b/darkcore/result_t.py
@@ -30,8 +30,10 @@ class ResultT(Generic[A]):
         def step(result: Result[A]) -> MonadLike[Any]:
             if isinstance(result, Err):
                 return self.run.pure(result)
-            else:
+            if isinstance(result, Ok):
                 return f(result.value).run
+            # This branch should be unreachable but is included for completeness
+            raise TypeError("Unexpected Result subtype")
         return ResultT(self.run.bind(step))
 
     def __eq__(self, other: object) -> bool:

--- a/tests/test_either_t.py
+++ b/tests/test_either_t.py
@@ -1,0 +1,68 @@
+from darkcore.either import Left, Right
+from darkcore.either_t import EitherT
+
+class DummyMonad:
+    """Minimal monad for testing (only carries a value)."""
+    def __init__(self, value):
+        self.value = value
+
+    @staticmethod
+    def pure(x):
+        return DummyMonad(x)
+
+    def fmap(self, f):
+        return DummyMonad(f(self.value))
+
+    def bind(self, f):
+        return f(self.value)
+
+    def __eq__(self, other):
+        return isinstance(other, DummyMonad) and self.value == other.value
+
+    def __repr__(self):
+        return f"DummyMonad({self.value!r})"
+
+
+def test_lift():
+    m = DummyMonad(10)
+    et = EitherT.lift(m)
+    assert isinstance(et, EitherT)
+    assert et.run == DummyMonad(Right(10))
+
+
+def test_map():
+    m = DummyMonad(Right(3))
+    et = EitherT(m)
+    et2 = et.map(lambda x: x + 1)
+    assert et2.run == DummyMonad(Right(4))
+
+
+def test_bind_right():
+    m = DummyMonad(Right(2))
+    et = EitherT(m)
+
+    def f(x):
+        return EitherT(DummyMonad(Right(x * 10)))
+
+    result = et.bind(f)
+    assert result.run == DummyMonad(Right(20))
+
+
+def test_bind_left():
+    m = DummyMonad(Left("fail"))
+    et = EitherT(m)
+
+    def f(x):
+        return EitherT(DummyMonad(Right(x * 10)))
+
+    result = et.bind(f)
+    assert result.run == DummyMonad(Left("fail"))
+
+
+def test_ap():
+    mf = DummyMonad(Right(lambda x: x + 5))
+    mx = DummyMonad(Right(7))
+    etf = EitherT(mf)
+    etx = EitherT(mx)
+    result = etf.ap(etx)
+    assert result.run == DummyMonad(Right(12))

--- a/tests/test_result_t.py
+++ b/tests/test_result_t.py
@@ -1,0 +1,68 @@
+from darkcore.result import Ok, Err
+from darkcore.result_t import ResultT
+
+class DummyMonad:
+    """Minimal monad for testing (only carries a value)."""
+    def __init__(self, value):
+        self.value = value
+
+    @staticmethod
+    def pure(x):
+        return DummyMonad(x)
+
+    def fmap(self, f):
+        return DummyMonad(f(self.value))
+
+    def bind(self, f):
+        return f(self.value)
+
+    def __eq__(self, other):
+        return isinstance(other, DummyMonad) and self.value == other.value
+
+    def __repr__(self):
+        return f"DummyMonad({self.value!r})"
+
+
+def test_lift():
+    m = DummyMonad(10)
+    rt = ResultT.lift(m)
+    assert isinstance(rt, ResultT)
+    assert rt.run == DummyMonad(Ok(10))
+
+
+def test_map():
+    m = DummyMonad(Ok(3))
+    rt = ResultT(m)
+    rt2 = rt.map(lambda x: x + 1)
+    assert rt2.run == DummyMonad(Ok(4))
+
+
+def test_bind_ok():
+    m = DummyMonad(Ok(2))
+    rt = ResultT(m)
+
+    def f(x):
+        return ResultT(DummyMonad(Ok(x * 10)))
+
+    result = rt.bind(f)
+    assert result.run == DummyMonad(Ok(20))
+
+
+def test_bind_err():
+    m = DummyMonad(Err("fail"))
+    rt = ResultT(m)
+
+    def f(x):
+        return ResultT(DummyMonad(Ok(x * 10)))
+
+    result = rt.bind(f)
+    assert result.run == DummyMonad(Err("fail"))
+
+
+def test_ap():
+    mf = DummyMonad(Ok(lambda x: x + 5))
+    mx = DummyMonad(Ok(7))
+    rtf = ResultT(mf)
+    rtx = ResultT(mx)
+    result = rtf.ap(rtx)
+    assert result.run == DummyMonad(Ok(12))


### PR DESCRIPTION
## Summary
- implement EitherT and ResultT monad transformers
- export transformers from package
- test transformer behaviors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8a5a6343c832fa0417f9cef38265c