### PR TITLE
feat: add monad operator DSL and writer generalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,5 @@ jobs:
           python-version: "3.12"
       - run: pip install poetry
       - run: poetry install
-      - run: poetry run pytest --cov=darkcore
-      - run: poetry run mypy darkcore
+      - run: poetry run pytest -v --cov=darkcore
+      - run: poetry run mypy --strict darkcore

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ from darkcore.writer import Writer
 w = Writer.pure(3).tell(["start"]) >> (lambda x: Writer(x + 1, ["inc"]))
 print(w)  # Writer(4, log=['start', 'inc'])
 
-# string log with custom empty/combine
-w2 = Writer("hi", empty=str).tell("!")
+# for non-``list`` logs, pass ``empty`` and ``combine`` explicitly
+w2 = Writer("hi", empty=str, combine=str.__add__).tell("!")
 print(w2)  # Writer('hi', log='!')
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and an expressive **operator DSL** (`|`, `>>`, `@`) that makes Python feel almos
   - `Reader` — dependency injection / environment
   - `Writer` — accumulate logs
   - `State` — stateful computations
-- Monad transformer: `MaybeT`
+- Monad transformers: `MaybeT`, `ResultT`
 - Operator overloads for concise DSL-style code:
   - `|` → `fmap` (map)
   - `>>` → `bind` (flatMap)
@@ -88,7 +88,7 @@ print(greet.run({"user": "Alice"}))  # "Hello Alice"
 ```python
 from darkcore.writer import Writer
 
-w = Writer.pure(3).tell("start") >> (lambda x: Writer(x+1, ["inc"]))
+w = Writer.pure(3).tell(["start"]) >> (lambda x: Writer(x + 1, ["inc"]))
 print(w)  # Writer(4, log=['start', 'inc'])
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and an expressive **operator DSL** (`|`, `>>`, `@`) that makes Python feel almos
   - `Reader` — dependency injection / environment
   - `Writer` — accumulate logs
   - `State` — stateful computations
-- Monad transformers: `MaybeT`, `ResultT`
+- Monad transformers: `MaybeT`, `ResultT`, `ReaderT`, `StateT`, `WriterT`
 - Operator overloads for concise DSL-style code:
   - `|` → `fmap` (map)
   - `>>` → `bind` (flatMap)
@@ -88,8 +88,13 @@ print(greet.run({"user": "Alice"}))  # "Hello Alice"
 ```python
 from darkcore.writer import Writer
 
+# list log by default
 w = Writer.pure(3).tell(["start"]) >> (lambda x: Writer(x + 1, ["inc"]))
 print(w)  # Writer(4, log=['start', 'inc'])
+
+# string log with custom empty/combine
+w2 = Writer("hi", empty=str).tell("!")
+print(w2)  # Writer('hi', log='!')
 ```
 
 ---
@@ -103,6 +108,16 @@ inc = State(lambda s: (s, s+1))
 prog = inc >> (lambda x: State(lambda s: (x+s, s)))
 
 print(prog.run(1))  # (3, 2)
+```
+
+### Operator DSL
+
+```python
+from darkcore.maybe import Maybe
+
+mf = Maybe(lambda x: x * 2)
+mx = Maybe(4)
+print((mf @ mx) | (lambda x: x + 1))  # Just(9)
 ```
 
 ---

--- a/darkcore/core.py
+++ b/darkcore/core.py
@@ -27,6 +27,7 @@ class Applicative(Protocol, Generic[A]):
         ...
 
 
+# プロトコル定義
 class Monad(Protocol, Generic[A]):
     """
     構造的サブタイピングで表現した最小限の Monad プロトコル。
@@ -48,3 +49,21 @@ class Monad(Protocol, Generic[A]):
     def fmap(self, f: Callable[[A], B]) -> Monad[B]:
         """文脈付き値に純粋関数を適用して m b を返す"""
         ...
+
+
+class MonadOpsMixin(Generic[A]):
+    """演算子 DSL を提供するミックスイン。
+
+    ``|`` は ``fmap``、``>>`` は ``bind``、``@`` は ``ap`` に対応する。
+    ``fmap``/``bind``/``ap`` を実装する型はこのミックスインを継承するだけで
+    これらの演算子を利用できる。
+    """
+
+    def __or__(self, f: Callable[[A], B]) -> Any:
+        return self.fmap(f)  # type: ignore[attr-defined]
+
+    def __rshift__(self, f: Callable[[A], Any]) -> Any:
+        return self.bind(f)  # type: ignore[attr-defined]
+
+    def __matmul__(self, fa: Any) -> Any:
+        return self.ap(fa)  # type: ignore[attr-defined]

--- a/darkcore/core.py
+++ b/darkcore/core.py
@@ -51,6 +51,19 @@ class Monad(Protocol, Generic[A]):
         ...
 
 
+class SupportsFmapBindAp(Protocol, Generic[A]):
+    """Protocol for types supporting ``fmap``, ``bind`` and ``ap``."""
+
+    def fmap(self, f: Callable[[A], B]) -> Any:  # pragma: no cover - structural
+        ...
+
+    def bind(self, f: Callable[[A], Any]) -> Any:  # pragma: no cover - structural
+        ...
+
+    def ap(self, fa: Any) -> Any:  # pragma: no cover - structural
+        ...
+
+
 class MonadOpsMixin(Generic[A]):
     """演算子 DSL を提供するミックスイン。
 
@@ -59,11 +72,11 @@ class MonadOpsMixin(Generic[A]):
     これらの演算子を利用できる。
     """
 
-    def __or__(self, f: Callable[[A], B]) -> Any:
-        return self.fmap(f)  # type: ignore[attr-defined]
+    def __or__(self: SupportsFmapBindAp[A], f: Callable[[A], B]) -> Any:
+        return self.fmap(f)
 
-    def __rshift__(self, f: Callable[[A], Any]) -> Any:
-        return self.bind(f)  # type: ignore[attr-defined]
+    def __rshift__(self: SupportsFmapBindAp[A], f: Callable[[A], Any]) -> Any:
+        return self.bind(f)
 
-    def __matmul__(self, fa: Any) -> Any:
-        return self.ap(fa)  # type: ignore[attr-defined]
+    def __matmul__(self: SupportsFmapBindAp[A], fa: Any) -> Any:
+        return self.ap(fa)

--- a/darkcore/either.py
+++ b/darkcore/either.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 from typing import Callable, Generic, TypeVar, Any, cast
-from .core import Monad
+from .core import Monad, MonadOpsMixin
 
 A = TypeVar("A")
 B = TypeVar("B")
 
 
-class Either(Monad[A], Generic[A]):
+class Either(MonadOpsMixin[A], Monad[A], Generic[A]):
     # fmap は具象側で実装
     def fmap(self, f: Callable[[A], B]) -> "Either[B]":
         raise NotImplementedError

--- a/darkcore/maybe.py
+++ b/darkcore/maybe.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 from typing import Callable, Generic, Optional, TypeVar
+from .core import MonadOpsMixin
 
 A = TypeVar("A")
 B = TypeVar("B")
 
-class Maybe(Generic[A]):
+class Maybe(MonadOpsMixin[A], Generic[A]):
     __slots__ = ("_value",)
 
     def __init__(self, value: Optional[A]) -> None:

--- a/darkcore/maybe_t.py
+++ b/darkcore/maybe_t.py
@@ -17,8 +17,10 @@ class MaybeT(Generic[A]):
     def lift(cls, monad: MonadLike[A]) -> "MaybeT[A]":
         return MaybeT(monad.bind(lambda x: monad.pure(Maybe(x))))  # type: ignore[arg-type]
 
-    def map(self, f: Callable[[A], B]) -> "MaybeT[B]":
+    def fmap(self, f: Callable[[A], B]) -> "MaybeT[B]":
         return MaybeT(self.run.bind(lambda maybe: self.run.pure(maybe.fmap(f))))
+
+    map = fmap
 
     def ap(self: "MaybeT[Callable[[A], B]]", fa: "MaybeT[A]") -> "MaybeT[B]":
         return MaybeT(self.run.bind(lambda mf: fa.run.bind(lambda mx: self.run.pure(mf.ap(mx)))))

--- a/darkcore/reader.py
+++ b/darkcore/reader.py
@@ -1,18 +1,27 @@
 from __future__ import annotations
 from typing import Callable, Generic, TypeVar
+from .core import MonadOpsMixin
 
 A = TypeVar("A")
 B = TypeVar("B")
 C = TypeVar("C")
 
 
-class Reader(Generic[A, B]):
+class Reader(MonadOpsMixin[B], Generic[A, B]):
     def __init__(self, run: Callable[[A], B]) -> None:
         self.run = run
 
     @classmethod
-    def pure(cls, value: B) -> Reader[A, B]:
+    def pure(cls, value: B) -> "Reader[A, B]":
         return Reader(lambda _: value)
 
-    def bind(self, f: Callable[[B], Reader[A, C]]) -> Reader[A, C]:
+    def fmap(self, f: Callable[[B], C]) -> "Reader[A, C]":
+        return Reader(lambda r: f(self.run(r)))
+
+    map = fmap
+
+    def ap(self: "Reader[A, Callable[[B], C]]", fa: "Reader[A, B]") -> "Reader[A, C]":
+        return Reader(lambda r: self.run(r)(fa.run(r)))
+
+    def bind(self, f: Callable[[B], "Reader[A, C]"]) -> "Reader[A, C]":
         return Reader(lambda r: f(self.run(r)).run(r))

--- a/darkcore/reader_t.py
+++ b/darkcore/reader_t.py
@@ -18,6 +18,16 @@ class ReaderT(Generic[R, A]):
     def pure(cls, value: A) -> "ReaderT[R, A]":
         raise NotImplementedError("ReaderT.pure not implemented (needs monad context)")
 
+    def fmap(self, f: Callable[[A], B]) -> "ReaderT[R, B]":
+        return ReaderT(lambda env: self.run(env).fmap(f))
+
+    map = fmap
+
+    def ap(self: "ReaderT[R, Callable[[A], B]]", fa: "ReaderT[R, A]") -> "ReaderT[R, B]":
+        return ReaderT(
+            lambda env: self.run(env).bind(lambda func: fa.run(env).fmap(func))
+        )
+
     def bind(self, f: Callable[[A], "ReaderT[R, B]"]) -> "ReaderT[R, B]":
         def new_run(env: R) -> MonadLike[B]:
             inner = self.run(env)
@@ -32,3 +42,6 @@ class ReaderT(Generic[R, A]):
 
     def __repr__(self) -> str:
         return f"ReaderT({self.run!r})"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, ReaderT) and self.run == other.run

--- a/darkcore/reader_t.py
+++ b/darkcore/reader_t.py
@@ -18,6 +18,16 @@ class ReaderT(Generic[R, A]):
     def pure(cls, value: A) -> "ReaderT[R, A]":
         raise NotImplementedError("ReaderT.pure not implemented (needs monad context)")
 
+    @classmethod
+    def pure_with(
+        cls, pure: Callable[[A], MonadLike[A]], value: A
+    ) -> "ReaderT[R, A]":
+        """Construct a ``ReaderT`` using a provided ``pure`` for the base monad.
+
+        Needed because Python lacks higher-kinded types.
+        """
+        return ReaderT(lambda _r: pure(value))
+
     def fmap(self, f: Callable[[A], B]) -> "ReaderT[R, B]":
         return ReaderT(lambda env: self.run(env).fmap(f))
 
@@ -42,6 +52,3 @@ class ReaderT(Generic[R, A]):
 
     def __repr__(self) -> str:
         return f"ReaderT({self.run!r})"
-
-    def __eq__(self, other: object) -> bool:
-        return isinstance(other, ReaderT) and self.run == other.run

--- a/darkcore/result.py
+++ b/darkcore/result.py
@@ -17,6 +17,9 @@ class Result(MonadOpsMixin[A], Monad[A], Generic[A]):
     def map(self, f: Callable[[A], B]) -> "Result[B]":
         return self.fmap(f)
 
+    def ap(self, fa: "Result[Any]") -> "Result[Any]":  # pragma: no cover - interface
+        raise NotImplementedError
+
     def __eq__(self, other: object) -> bool:
         return isinstance(other, Result) and self.__dict__ == other.__dict__
 

--- a/darkcore/result.py
+++ b/darkcore/result.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 from typing import Callable, Generic, TypeVar, Any, cast
-from .core import Monad
+from .core import Monad, MonadOpsMixin
 
 A = TypeVar("A")
 B = TypeVar("B")
 
 
-class Result(Monad[A], Generic[A]):
+class Result(MonadOpsMixin[A], Monad[A], Generic[A]):
     """
     Result は構造的に Monad を満たす成功/失敗の直和型。
     fmap は具象側で実装し、ここではシグネチャだけ宣言する。
@@ -19,12 +19,6 @@ class Result(Monad[A], Generic[A]):
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, Result) and self.__dict__ == other.__dict__
-
-    def __rshift__(self, f: Callable[[A], "Result[B]"]) -> "Result[B]":
-        return cast(Result[B], self.bind(f))
-
-    def __or__(self, f: Callable[[A], B]) -> "Result[B]":
-        return self.fmap(f)
 
 class Ok(Result[A]):
     def __init__(self, value: A) -> None:

--- a/darkcore/result_t.py
+++ b/darkcore/result_t.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Callable, Generic, TypeVar, Any
+from typing import Callable, Generic, TypeVar, Any, cast
 from .core import Monad as MonadLike
 from .result import Result, Ok, Err
 
@@ -7,33 +7,49 @@ A = TypeVar("A")
 B = TypeVar("B")
 
 class ResultT(Generic[A]):
-    """Monad transformer for Result.
+    """Monad transformer for :class:`~darkcore.result.Result`.
 
-    Wraps: m (Result a)
+    Wraps ``m (Result a)``.
     """
 
-    def __init__(self, run: MonadLike[Any]) -> None:
-        self.run: MonadLike[Any] = run
+    def __init__(self, run: MonadLike[Result[A]]) -> None:
+        self.run = run
 
     @classmethod
     def lift(cls, monad: MonadLike[A]) -> "ResultT[A]":
-        """Lift a monad into ResultT."""
-        return ResultT(monad.bind(lambda x: monad.pure(Ok(x))))  # type: ignore[arg-type]
+        def step(x: A) -> MonadLike[Result[A]]:
+            return cast(MonadLike[Result[A]], cast(Any, monad).pure(Ok(x)))
+        return ResultT(cast(MonadLike[Result[A]], monad.bind(step)))
 
-    def map(self, f: Callable[[A], B]) -> "ResultT[B]":
-        return ResultT(self.run.bind(lambda r: self.run.pure(r.fmap(f))))
+    def fmap(self, f: Callable[[A], B]) -> "ResultT[B]":
+        def step(res: Result[A]) -> MonadLike[Result[B]]:
+            if isinstance(res, Err):
+                return cast(MonadLike[Result[B]], self.run.pure(res))
+            ok = cast(Ok[A], res)
+            return cast(
+                MonadLike[Result[B]],
+                cast(Any, self.run).pure(cast(Result[B], Ok(f(ok.value))))
+            )
+
+        return ResultT(self.run.bind(step))
+
+    map = fmap
 
     def ap(self: "ResultT[Callable[[A], B]]", fa: "ResultT[A]") -> "ResultT[B]":
-        return ResultT(self.run.bind(lambda mf: fa.run.bind(lambda mx: self.run.pure(mf.ap(mx)))))
+        return ResultT(
+            self.run.bind(
+                lambda mf: fa.run.bind(
+                    lambda mx: cast(MonadLike[Result[B]], self.run.pure(mf.ap(mx)))
+                )
+            )
+        )
 
     def bind(self, f: Callable[[A], "ResultT[B]"]) -> "ResultT[B]":
-        def step(result: Result[A]) -> MonadLike[Any]:
-            if isinstance(result, Err):
-                return self.run.pure(result)
-            if isinstance(result, Ok):
-                return f(result.value).run
-            # This branch should be unreachable but is included for completeness
-            raise TypeError("Unexpected Result subtype")
+        def step(res: Result[A]) -> MonadLike[Result[B]]:
+            if isinstance(res, Err):
+                return cast(MonadLike[Result[B]], self.run.pure(res))
+            ok = cast(Ok[A], res)
+            return f(ok.value).run
         return ResultT(self.run.bind(step))
 
     def __eq__(self, other: object) -> bool:

--- a/darkcore/state_t.py
+++ b/darkcore/state_t.py
@@ -26,6 +26,13 @@ class StateT(Generic[S, A]):
             return monad.bind(step)
         return StateT(run)
 
+    @classmethod
+    def pure_with(
+        cls, pure: Callable[[tuple[A, S]], Monad[tuple[A, S]]], value: A
+    ) -> "StateT[S, A]":
+        """Construct ``StateT`` with provided ``pure`` (workaround for lack of HKTs)."""
+        return StateT(lambda s: pure((value, s)))
+
     def fmap(self, f: Callable[[A], B]) -> "StateT[S, B]":
         def new_run(s: S) -> Monad[tuple[B, S]]:
             return self.run(s).fmap(lambda pair: (f(pair[0]), pair[1]))
@@ -62,6 +69,3 @@ class StateT(Generic[S, A]):
 
     def __repr__(self) -> str:
         return f"StateT({self.run!r})"
-
-    def __eq__(self, other: object) -> bool:
-        return isinstance(other, StateT) and self.run == other.run

--- a/darkcore/writer.py
+++ b/darkcore/writer.py
@@ -1,31 +1,58 @@
 from __future__ import annotations
-from typing import Callable, Generic, TypeVar, Tuple, List
+from typing import Callable, Generic, TypeVar, cast
+from .core import MonadOpsMixin
 
 A = TypeVar("A")
 B = TypeVar("B")
-C = TypeVar("C")
+W = TypeVar("W")
 
-class Writer(Generic[A]):
-    def __init__(self, value: A, log: List[str] | None = None) -> None:
+
+class Writer(MonadOpsMixin[A], Generic[A, W]):
+    """Writer モナド。
+
+    ログ型 ``W`` はモノイドを想定し、デフォルトでは ``list`` を用いる。
+    ``combine`` を差し替えることで他のモノイドにも対応できる。
+    """
+
+    def __init__(
+        self,
+        value: A,
+        log: W | None = None,
+        *,
+        combine: Callable[[W, W], W] | None = None,
+    ) -> None:
         self.value = value
-        self.log: List[str] = log or []
+        self.log: W = cast(W, []) if log is None else log
+        self.combine: Callable[[W, W], W] = combine or cast(Callable[[W, W], W], lambda a, b: a + b)
 
     @classmethod
-    def pure(cls, value: A) -> Writer[A]:
-        return Writer(value, [])
+    def pure(
+        cls,
+        value: A,
+        log: W | None = None,
+        *,
+        combine: Callable[[W, W], W] | None = None,
+    ) -> "Writer[A, W]":
+        return cls(value, log, combine=combine)
 
-    def fmap(self, f: Callable[[A], B]) -> Writer[B]:
-        return Writer(f(self.value), self.log)
+    def fmap(self, f: Callable[[A], B]) -> "Writer[B, W]":
+        return Writer(f(self.value), self.log, combine=self.combine)
 
-    def bind(self, f: Callable[[A], Writer[B]]) -> Writer[B]:
+    map = fmap
+
+    def ap(self: "Writer[Callable[[A], B], W]", fa: "Writer[A, W]") -> "Writer[B, W]":
+        return Writer(self.value(fa.value), self.combine(self.log, fa.log), combine=self.combine)
+
+    def bind(self, f: Callable[[A], "Writer[B, W]"]) -> "Writer[B, W]":
         result = f(self.value)
-        return Writer(result.value, self.log + result.log)
+        return Writer(result.value, self.combine(self.log, result.log), combine=self.combine)
 
-    def tell(self, msg: str) -> Writer[A]:
-        return Writer(self.value, self.log + [msg])
+    def tell(self, msg: W) -> "Writer[A, W]":
+        return Writer(self.value, self.combine(self.log, msg), combine=self.combine)
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, Writer) and self.value == other.value and self.log == other.log
 
     def __repr__(self) -> str:
         return f"Writer({self.value!r}, log={self.log!r})"
+

--- a/darkcore/writer.py
+++ b/darkcore/writer.py
@@ -20,10 +20,12 @@ class Writer(MonadOpsMixin[A], Generic[A, W]):
         log: W | None = None,
         *,
         combine: Callable[[W, W], W] | None = None,
+        empty: Callable[[], W] | None = None,
     ) -> None:
         self.value = value
-        self.log: W = cast(W, []) if log is None else log
         self.combine: Callable[[W, W], W] = combine or cast(Callable[[W, W], W], lambda a, b: a + b)
+        self.empty: Callable[[], W] = empty or cast(Callable[[], W], list)
+        self.log: W = log if log is not None else self.empty()
 
     @classmethod
     def pure(
@@ -32,23 +34,24 @@ class Writer(MonadOpsMixin[A], Generic[A, W]):
         log: W | None = None,
         *,
         combine: Callable[[W, W], W] | None = None,
+        empty: Callable[[], W] | None = None,
     ) -> "Writer[A, W]":
-        return cls(value, log, combine=combine)
+        return cls(value, log, combine=combine, empty=empty)
 
     def fmap(self, f: Callable[[A], B]) -> "Writer[B, W]":
-        return Writer(f(self.value), self.log, combine=self.combine)
+        return Writer(f(self.value), self.log, combine=self.combine, empty=self.empty)
 
     map = fmap
 
     def ap(self: "Writer[Callable[[A], B], W]", fa: "Writer[A, W]") -> "Writer[B, W]":
-        return Writer(self.value(fa.value), self.combine(self.log, fa.log), combine=self.combine)
+        return Writer(self.value(fa.value), self.combine(self.log, fa.log), combine=self.combine, empty=self.empty)
 
     def bind(self, f: Callable[[A], "Writer[B, W]"]) -> "Writer[B, W]":
         result = f(self.value)
-        return Writer(result.value, self.combine(self.log, result.log), combine=self.combine)
+        return Writer(result.value, self.combine(self.log, result.log), combine=self.combine, empty=self.empty)
 
     def tell(self, msg: W) -> "Writer[A, W]":
-        return Writer(self.value, self.combine(self.log, msg), combine=self.combine)
+        return Writer(self.value, self.combine(self.log, msg), combine=self.combine, empty=self.empty)
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, Writer) and self.value == other.value and self.log == other.log

--- a/darkcore/writer_t.py
+++ b/darkcore/writer_t.py
@@ -1,47 +1,43 @@
 from __future__ import annotations
-from typing import Generic, TypeVar, List, Callable, Any, cast
+from typing import Generic, TypeVar, Callable, Any, cast
 from .core import Monad
 
 A = TypeVar("A")
 B = TypeVar("B")
-W = TypeVar("W")  # ログ型（モノイド想定：ここでは List[W] を連結）
+W = TypeVar("W")  # ログ型（モノイド）
+
 
 class WriterT(Generic[A, W]):
-    """
-    WriterT m a ≅ m (a, w)
-    ここで w はモノイド（リスト連結で代用）。
-    """
-    def __init__(self, run: Monad[tuple[A, List[W]]]) -> None:
+    """Writer モナドトランスフォーマー。``m (a, w)`` を包む。"""
+
+    def __init__(self, run: Monad[tuple[A, W]], combine: Callable[[W, W], W] | None = None) -> None:
         self.run = run
+        self.combine: Callable[[W, W], W] = combine or cast(Callable[[W, W], W], lambda a, b: a + b)
 
     @classmethod
-    def lift(cls, monad: Monad[A], empty_log: List[W]) -> "WriterT[A, W]":
-        """
-        m a -> WriterT m a
-        実装上は: monad.bind(lambda a: monad.pure((a, empty_log)))
-        ただし mypy の型変数不一致を回避するため cast を用いる。
-        """
-        def step(a: A) -> Monad[tuple[A, List[W]]]:
-            # monad.pure は A に限らず「そのモナドの型パラメタ全体」に対して多相だが、
-            # Python の型システムでは単相に見えるため Any/cast で橋渡しする。
-            return cast(Monad[tuple[A, List[W]]],
-                        cast(Any, monad).pure((a, empty_log)))
-        return WriterT(monad.bind(step))
+    def lift(
+        cls, monad: Monad[A], empty_log: W, *, combine: Callable[[W, W], W] | None = None
+    ) -> "WriterT[A, W]":
+        """m a -> WriterT m a"""
+        combine_fn: Callable[[W, W], W] = combine or cast(Callable[[W, W], W], lambda a, b: a + b)
+
+        def step(a: A) -> Monad[tuple[A, W]]:
+            # 型変数不一致を回避するため Any/cast を用いる。
+            return cast(Monad[tuple[A, W]], cast(Any, monad).pure((a, empty_log)))
+
+        return WriterT(monad.bind(step), combine=combine_fn)
 
     def bind(self, f: Callable[[A], "WriterT[B, W]"]) -> "WriterT[B, W]":
-        """
-        (a, w1) を取り出し、f(a) の run = m (b, w2) を連鎖。
-        ログは w1 ++ w2（ここではリスト結合）。
-        """
-        def step(pair: tuple[A, List[W]]) -> Monad[tuple[B, List[W]]]:
+        def step(pair: tuple[A, W]) -> Monad[tuple[B, W]]:
             (a, log1) = pair
-            # f(a).run: Monad[(B, List[W])]
             return f(a).run.bind(
-                lambda res: cast(Monad[tuple[B, List[W]]],
-                                 cast(Any, self.run).pure((res[0], log1 + res[1])))
+                lambda res: cast(
+                    Monad[tuple[B, W]],
+                    cast(Any, self.run).pure((res[0], self.combine(log1, res[1]))),
+                )
             )
 
-        return WriterT(self.run.bind(step))
+        return WriterT(self.run.bind(step), combine=self.combine)
 
     def __rshift__(self, f: Callable[[A], "WriterT[B, W]"]) -> "WriterT[B, W]":
         return self.bind(f)

--- a/darkcore/writer_t.py
+++ b/darkcore/writer_t.py
@@ -27,6 +27,18 @@ class WriterT(Generic[A, W]):
 
         return WriterT(monad.bind(step), combine=combine_fn)
 
+    @classmethod
+    def pure_with(
+        cls,
+        pure: Callable[[tuple[A, W]], Monad[tuple[A, W]]],
+        value: A,
+        *,
+        empty: Callable[[], W],
+        combine: Callable[[W, W], W] | None = None,
+    ) -> "WriterT[A, W]":
+        """Construct ``WriterT`` with a supplied ``pure`` and ``empty`` (no HKTs)."""
+        return WriterT(pure((value, empty())), combine=combine)
+
     def fmap(self, f: Callable[[A], B]) -> "WriterT[B, W]":
         return WriterT(self.run.fmap(lambda pair: (f(pair[0]), pair[1])), combine=self.combine)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ strict = true
 ignore_missing_imports = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
-disable_error_code = ["misc"]  
+disable_error_code = ["misc"]
+files = ["darkcore"]
 
 [tool.pytest.ini_options]
 addopts = "-v --cov=darkcore"

--- a/tests/test_either.py
+++ b/tests/test_either.py
@@ -2,17 +2,17 @@ from darkcore.either import Left, Right
 
 def test_right_map_and_bind():
     r = Right(10)
-    r2 = r.map(lambda x: x + 5)
+    r2 = r | (lambda x: x + 5)
     assert isinstance(r2, Right)
     assert r2.value == 15
 
-    r3 = r.bind(lambda x: Right(x * 2))
+    r3 = r >> (lambda x: Right(x * 2))
     assert r3 == Right(20)
 
 def test_left_propagates():
     l = Left("error")
-    assert l.map(lambda x: x + 1) == l
-    assert l.bind(lambda x: Right(x * 2)) == l
+    assert (l | (lambda x: x + 1)) == l
+    assert l >> (lambda x: Right(x * 2)) == l
 
 def test_monad_laws():
     f = lambda x: Right(x + 1)
@@ -25,3 +25,10 @@ def test_monad_laws():
     assert m.bind(Right.pure) == m
     # 結合律
     assert m.bind(f).bind(g) == m.bind(lambda y: f(y).bind(g))
+
+
+def test_either_ap_operator():
+    rf = Right(lambda x: x + 1)
+    rx = Right(2)
+    assert rf @ rx == Right(3)
+    assert Left("e") @ rx == Left("e")

--- a/tests/test_maybe.py
+++ b/tests/test_maybe.py
@@ -34,6 +34,17 @@ def test_maybe_ap_none_value():
     result = mf.ap(mx)
     assert result.is_nothing()
 
+
+def test_maybe_ap_operator():
+    mf = Maybe(lambda x: x * 2)
+    mx = Maybe(4)
+    assert (mf @ mx).get_or_else(0) == 8
+
+
+def test_maybe_map_operator():
+    m = Maybe(3) | (lambda x: x + 1)
+    assert m.get_or_else(0) == 4
+
 def test_monad_left_identity():
     f = lambda x: Maybe(x + 1)
     x = 5

--- a/tests/test_maybe_t.py
+++ b/tests/test_maybe_t.py
@@ -1,5 +1,6 @@
 from darkcore.maybe import Maybe
 from darkcore.maybe_t import MaybeT
+import pytest
 
 class DummyMonad:
     """テスト用の最小Monad実装（Just値しか持たない）"""
@@ -66,3 +67,60 @@ def test_ap():
 
     result = mtf.ap(mtx)
     assert result.run == DummyMonad(Maybe(12))
+
+
+# Functor laws
+@pytest.mark.parametrize("x", [1, 2])
+def test_maybe_t_functor_identity(x):
+    m = MaybeT.lift(DummyMonad(x))
+    assert m.fmap(lambda a: a) == m
+
+
+@pytest.mark.parametrize("x", [3])
+def test_maybe_t_functor_composition(x):
+    m = MaybeT.lift(DummyMonad(x))
+    f = lambda y: y + 1
+    g = lambda y: y * 2
+    assert m.fmap(lambda y: f(g(y))) == m.fmap(g).fmap(f)
+
+
+# Applicative laws
+def test_maybe_t_applicative_identity():
+    v = MaybeT.lift(DummyMonad(3))
+    pure_id = MaybeT.lift(DummyMonad(lambda x: x))
+    assert pure_id.ap(v) == v
+
+
+def test_maybe_t_applicative_homomorphism():
+    f = lambda x: x + 1
+    x = 3
+    left = MaybeT.lift(DummyMonad(f)).ap(MaybeT.lift(DummyMonad(x)))
+    right = MaybeT.lift(DummyMonad(f(x)))
+    assert left == right
+
+
+def test_maybe_t_applicative_interchange():
+    u = MaybeT.lift(DummyMonad(lambda x: x * 2))
+    y = 7
+    left = u.ap(MaybeT.lift(DummyMonad(y)))
+    right = MaybeT.lift(DummyMonad(lambda f: f(y))).ap(u)
+    assert left == right
+
+
+# Monad laws
+def test_maybe_t_monad_left_identity():
+    f = lambda x: MaybeT.lift(DummyMonad(x + 1))
+    x = 5
+    assert MaybeT.lift(DummyMonad(x)).bind(f) == f(x)
+
+
+def test_maybe_t_monad_right_identity():
+    m = MaybeT.lift(DummyMonad(4))
+    assert m.bind(lambda a: MaybeT.lift(DummyMonad(a))) == m
+
+
+def test_maybe_t_monad_associativity():
+    m = MaybeT.lift(DummyMonad(3))
+    f = lambda x: MaybeT.lift(DummyMonad(x + 1))
+    g = lambda y: MaybeT.lift(DummyMonad(y * 2))
+    assert m.bind(f).bind(g) == m.bind(lambda x: f(x).bind(g))

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,4 +1,5 @@
 from darkcore.reader import Reader
+import pytest
 
 
 def test_reader_basic():
@@ -23,3 +24,69 @@ def test_reader_ap_operator():
     rx = Reader(lambda env: env * 2)
     r = rf @ rx
     assert r.run(3) == 9
+
+
+# Functor laws
+@pytest.mark.parametrize("env", [0, 1, 5])
+def test_reader_functor_identity(env):
+    r = Reader(lambda e: e + 1)
+    assert (r | (lambda x: x)).run(env) == r.run(env)
+
+
+@pytest.mark.parametrize("env", [0, 2])
+def test_reader_functor_composition(env):
+    r = Reader(lambda e: e * 2)
+    f = lambda x: x + 3
+    g = lambda x: x * 4
+    lhs = r | (lambda x: f(g(x)))
+    rhs = (r | g) | f
+    assert lhs.run(env) == rhs.run(env)
+
+
+# Applicative laws
+@pytest.mark.parametrize("env", [1, 3])
+def test_reader_applicative_identity(env):
+    v = Reader(lambda e: e + 5)
+    assert (Reader.pure(lambda x: x) @ v).run(env) == v.run(env)
+
+
+@pytest.mark.parametrize("env", [0])
+def test_reader_applicative_homomorphism(env):
+    f = lambda x: x + 1
+    x = 3
+    left = Reader.pure(f) @ Reader.pure(x)
+    right = Reader.pure(f(x))
+    assert left.run(env) == right.run(env)
+
+
+@pytest.mark.parametrize("env", [2])
+def test_reader_applicative_interchange(env):
+    u = Reader.pure(lambda x: x * 2)
+    y = 7
+    left = u @ Reader.pure(y)
+    right = Reader.pure(lambda f: f(y)) @ u
+    assert left.run(env) == right.run(env)
+
+
+# Monad laws
+@pytest.mark.parametrize("env", [0, 4])
+def test_reader_monad_left_identity(env):
+    f = lambda x: Reader(lambda r: x + r)
+    x = 5
+    assert Reader.pure(x).bind(f).run(env) == f(x).run(env)
+
+
+@pytest.mark.parametrize("env", [1, 2])
+def test_reader_monad_right_identity(env):
+    m = Reader(lambda r: r * 2)
+    assert m.bind(Reader.pure).run(env) == m.run(env)
+
+
+@pytest.mark.parametrize("env", [3])
+def test_reader_monad_associativity(env):
+    m = Reader(lambda r: r + 1)
+    f = lambda x: Reader(lambda r: x * r)
+    g = lambda y: Reader(lambda r: y - r)
+    left = m.bind(f).bind(g)
+    right = m.bind(lambda x: f(x).bind(g))
+    assert left.run(env) == right.run(env)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,11 +1,25 @@
 from darkcore.reader import Reader
 
+
 def test_reader_basic():
     r = Reader(lambda env: env + 1)
     assert r.run(10) == 11
 
+
+def test_reader_map_operator():
+    r = Reader(lambda env: env) | (lambda x: x + 1)
+    assert r.run(2) == 3
+
+
 def test_reader_bind():
     r = Reader(lambda env: env * 2)
-    s = r.bind(lambda x: Reader(lambda env: x + env))
+    s = r >> (lambda x: Reader(lambda env: x + env))
     # env=3 のとき: r=6, その後 f(6) = Reader(lambda env: 6+env)=9
     assert s.run(3) == 9
+
+
+def test_reader_ap_operator():
+    rf = Reader(lambda env: lambda x: x + env)
+    rx = Reader(lambda env: env * 2)
+    r = rf @ rx
+    assert r.run(3) == 9

--- a/tests/test_reader_t.py
+++ b/tests/test_reader_t.py
@@ -1,5 +1,7 @@
 from darkcore.result import Ok, Err
 from darkcore.reader_t import ReaderT
+from darkcore.result import Ok
+import pytest
 
 def test_reader_t_lift():
     rt = ReaderT.lift(Ok(42))
@@ -33,3 +35,67 @@ def test_reader_t_composition():
 
     res = prog.run({"base": 5, "bonus": 3, "user": "alice"})
     assert res == Ok("user=alice, val=8")
+
+
+# Functor laws
+@pytest.mark.parametrize("env", [{"x": 1}, {"x": 2}])
+def test_reader_t_functor_identity(env):
+    r = ReaderT(lambda e: Ok(e["x"]))
+    assert r.fmap(lambda a: a).run(env) == r.run(env)
+
+
+@pytest.mark.parametrize("env", [{"x": 3}])
+def test_reader_t_functor_composition(env):
+    r = ReaderT(lambda e: Ok(e["x"]))
+    f = lambda y: y + 1
+    g = lambda y: y * 2
+    lhs = r.fmap(lambda y: f(g(y)))
+    rhs = r.fmap(g).fmap(f)
+    assert lhs.run(env) == rhs.run(env)
+
+
+# Applicative laws
+@pytest.mark.parametrize("env", [{"x": 5}])
+def test_reader_t_applicative_identity(env):
+    v = ReaderT(lambda e: Ok(e["x"]))
+    pure_id = ReaderT(lambda _: Ok(lambda x: x))
+    assert pure_id.ap(v).run(env) == v.run(env)
+
+
+def test_reader_t_applicative_homomorphism():
+    f = lambda x: x + 1
+    x = 3
+    left = ReaderT(lambda _: Ok(f)).ap(ReaderT(lambda _: Ok(x)))
+    right = ReaderT(lambda _: Ok(f(x)))
+    assert left.run({}) == right.run({})
+
+
+def test_reader_t_applicative_interchange():
+    u = ReaderT(lambda _: Ok(lambda x: x * 2))
+    y = 7
+    left = u.ap(ReaderT(lambda _: Ok(y)))
+    right = ReaderT(lambda _: Ok(lambda f: f(y))).ap(u)
+    assert left.run({}) == right.run({})
+
+
+# Monad laws
+@pytest.mark.parametrize("env", [{"x": 1}, {"x": 2}])
+def test_reader_t_monad_left_identity(env):
+    f = lambda x: ReaderT(lambda e: Ok(x + e["x"]))
+    x = 5
+    assert ReaderT(lambda _: Ok(x)).bind(f).run(env) == f(x).run(env)
+
+
+def test_reader_t_monad_right_identity():
+    m = ReaderT(lambda e: Ok(e["x"]))
+    assert m.bind(lambda a: ReaderT(lambda _: Ok(a))).run({"x": 3}) == m.run({"x": 3})
+
+
+def test_reader_t_monad_associativity():
+    m = ReaderT(lambda e: Ok(e["x"]))
+    f = lambda x: ReaderT(lambda e: Ok(x + e["x"]))
+    g = lambda y: ReaderT(lambda e: Ok(y * e["x"]))
+    env = {"x": 4}
+    left = m.bind(f).bind(g).run(env)
+    right = m.bind(lambda x: f(x).bind(g)).run(env)
+    assert left == right

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -24,3 +24,14 @@ def test_result_laws():
     assert m.bind(Ok.pure) == m
     # 結合律
     assert m.bind(f).bind(g) == m.bind(lambda y: f(y).bind(g))
+
+
+def test_result_map_operator():
+    assert (Ok(3) | (lambda x: x + 1)) == Ok(4)
+
+
+def test_result_ap_operator():
+    rf = Ok(lambda x: x + 1)
+    rx = Ok(2)
+    assert rf @ rx == Ok(3)
+    assert Err("e") @ rx == Err("e")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,5 +1,8 @@
 from darkcore.state import State
 
+from darkcore.state import State
+import pytest
+
 
 def test_state_basic():
     inc = State(lambda s: (s, s + 1))
@@ -31,3 +34,69 @@ def test_state_ap_operator():
     sx = State(lambda s: (s, s + 1))
     result, final = (sf @ sx).run(1)
     assert (result, final) == (2, 2)
+
+
+# Functor laws
+@pytest.mark.parametrize("s", [0, 5])
+def test_state_functor_identity(s):
+    st = State(lambda state: (state + 1, state))
+    assert (st | (lambda x: x)).run(s) == st.run(s)
+
+
+@pytest.mark.parametrize("s", [1, 2])
+def test_state_functor_composition(s):
+    st = State(lambda state: (state, state))
+    f = lambda x: x + 3
+    g = lambda x: x * 4
+    lhs = st | (lambda x: f(g(x)))
+    rhs = (st | g) | f
+    assert lhs.run(s) == rhs.run(s)
+
+
+# Applicative laws
+@pytest.mark.parametrize("s", [0, 3])
+def test_state_applicative_identity(s):
+    v = State(lambda state: (state + 2, state))
+    assert (State.pure(lambda x: x) @ v).run(s) == v.run(s)
+
+
+@pytest.mark.parametrize("s", [4])
+def test_state_applicative_homomorphism(s):
+    f = lambda x: x + 1
+    x = 3
+    left = State.pure(f) @ State.pure(x)
+    right = State.pure(f(x))
+    assert left.run(s) == right.run(s)
+
+
+@pytest.mark.parametrize("s", [2])
+def test_state_applicative_interchange(s):
+    u = State.pure(lambda x: x * 2)
+    y = 7
+    left = u @ State.pure(y)
+    right = State.pure(lambda f: f(y)) @ u
+    assert left.run(s) == right.run(s)
+
+
+# Monad laws
+@pytest.mark.parametrize("s", [0, 1])
+def test_state_monad_left_identity(s):
+    f = lambda x: State(lambda st: (x + st, st))
+    x = 5
+    assert State.pure(x).bind(f).run(s) == f(x).run(s)
+
+
+@pytest.mark.parametrize("s", [2, 3])
+def test_state_monad_right_identity(s):
+    m = State(lambda st: (st + 1, st))
+    assert m.bind(State.pure).run(s) == m.run(s)
+
+
+@pytest.mark.parametrize("s", [4])
+def test_state_monad_associativity(s):
+    m = State(lambda st: (st + 1, st))
+    f = lambda x: State(lambda st: (x * 2, st))
+    g = lambda y: State(lambda st: (y - 1, st))
+    left = m.bind(f).bind(g)
+    right = m.bind(lambda x: f(x).bind(g))
+    assert left.run(s) == right.run(s)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,17 +1,33 @@
 from darkcore.state import State
 
+
 def test_state_basic():
-    inc = State(lambda s: (s, s+1))
+    inc = State(lambda s: (s, s + 1))
     result, final = inc.run(0)
     assert result == 0 and final == 1
 
+
+def test_state_map_operator():
+    inc = State(lambda s: (s, s + 1))
+    result, final = (inc | (lambda x: x + 1)).run(0)
+    assert (result, final) == (1, 1)
+
+
 def test_state_bind():
-    inc = State(lambda s: (s, s+1))
-    prog = inc.bind(lambda x: State(lambda s: (x+s, s)))
+    inc = State(lambda s: (s, s + 1))
+    prog = inc >> (lambda x: State(lambda s: (x + s, s)))
     result, final = prog.run(1)
     assert (result, final) == (3, 2)
 
+
 def test_state_get_put():
-    prog = State.get().bind(lambda s: State.put(s+10).bind(lambda _: State.pure(s)))
+    prog = State.get() >> (lambda s: State.put(s + 10) >> (lambda _: State.pure(s)))
     result, final = prog.run(5)
     assert result == 5 and final == 15
+
+
+def test_state_ap_operator():
+    sf = State(lambda s: (lambda x: x + s, s))
+    sx = State(lambda s: (s, s + 1))
+    result, final = (sf @ sx).run(1)
+    assert (result, final) == (2, 2)

--- a/tests/test_state_t.py
+++ b/tests/test_state_t.py
@@ -1,5 +1,6 @@
 from darkcore.state_t import StateT
 from darkcore.result import Ok, Err
+import pytest
 
 def test_state_t_lift_and_run():
     st = StateT.lift(Ok(42))
@@ -29,3 +30,66 @@ def test_state_t_composition():
     prog = StateT(lambda s: Ok((s, s))) >> step1 >> step2
     result = prog.run(5)
     assert result == Ok(("val=6, state=6", 12))
+
+
+# Functor laws
+@pytest.mark.parametrize("s", [0, 1])
+def test_state_t_functor_identity(s):
+    st = StateT(lambda state: Ok((state + 1, state)))
+    assert st.fmap(lambda a: a).run(s) == st.run(s)
+
+
+@pytest.mark.parametrize("s", [2])
+def test_state_t_functor_composition(s):
+    st = StateT(lambda state: Ok((state, state)))
+    f = lambda x: x + 3
+    g = lambda x: x * 2
+    lhs = st.fmap(lambda x: f(g(x)))
+    rhs = st.fmap(g).fmap(f)
+    assert lhs.run(s) == rhs.run(s)
+
+
+# Applicative laws
+@pytest.mark.parametrize("s", [0])
+def test_state_t_applicative_identity(s):
+    v = StateT(lambda state: Ok((state + 2, state)))
+    pure_id = StateT(lambda state: Ok((lambda x: x, state)))
+    assert pure_id.ap(v).run(s) == v.run(s)
+
+
+def test_state_t_applicative_homomorphism():
+    f = lambda x: x + 1
+    x = 3
+    left = StateT(lambda s: Ok((f, s))).ap(StateT(lambda s: Ok((x, s))))
+    right = StateT(lambda s: Ok((f(x), s)))
+    assert left.run(0) == right.run(0)
+
+
+def test_state_t_applicative_interchange():
+    u = StateT(lambda s: Ok((lambda x: x * 2, s)))
+    y = 7
+    left = u.ap(StateT(lambda s: Ok((y, s))))
+    right = StateT(lambda s: Ok((lambda f: f(y), s))).ap(u)
+    assert left.run(0) == right.run(0)
+
+
+# Monad laws
+@pytest.mark.parametrize("s", [0, 1])
+def test_state_t_monad_left_identity(s):
+    f = lambda x: StateT(lambda st: Ok((x + st, st)))
+    x = 5
+    assert StateT(lambda st: Ok((x, st))).bind(f).run(s) == f(x).run(s)
+
+
+def test_state_t_monad_right_identity():
+    m = StateT(lambda s: Ok((s + 1, s)))
+    assert m.bind(lambda a: StateT(lambda s: Ok((a, s)))).run(0) == m.run(0)
+
+
+def test_state_t_monad_associativity():
+    m = StateT(lambda s: Ok((s + 1, s)))
+    f = lambda x: StateT(lambda s: Ok((x * 2, s)))
+    g = lambda y: StateT(lambda s: Ok((y - 1, s)))
+    left = m.bind(f).bind(g).run(0)
+    right = m.bind(lambda x: f(x).bind(g)).run(0)
+    assert left == right

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,10 +1,19 @@
 from darkcore.writer import Writer
 
+
 def test_writer_bind_and_tell():
-    w = Writer.pure(3).tell("start").bind(lambda x: Writer(x+1, ["inc"]))
+    w = Writer.pure(3).tell(["start"]) >> (lambda x: Writer(x + 1, ["inc"]))
     assert w.value == 4
     assert w.log == ["start", "inc"]
 
+
 def test_writer_fmap():
-    w = Writer(5, ["init"]).fmap(lambda x: x * 2)
+    w = Writer(5, ["init"]) | (lambda x: x * 2)
     assert w == Writer(10, ["init"])
+
+
+def test_writer_ap_and_operator():
+    wf = Writer(lambda x: x + 1, ["f"])
+    wx = Writer(2, ["x"])
+    res = wf @ wx
+    assert res == Writer(3, ["f", "x"])

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,4 +1,6 @@
 from darkcore.writer import Writer
+from darkcore.writer import Writer
+import pytest
 
 
 def test_writer_bind_and_tell():
@@ -17,3 +19,57 @@ def test_writer_ap_and_operator():
     wx = Writer(2, ["x"])
     res = wf @ wx
     assert res == Writer(3, ["f", "x"])
+
+
+# Functor laws
+def test_writer_functor_identity():
+    w = Writer(3, ["log"])
+    assert (w | (lambda x: x)) == w
+
+
+def test_writer_functor_composition():
+    w = Writer(2, ["log"])
+    f = lambda x: x + 3
+    g = lambda x: x * 4
+    assert (w | (lambda x: f(g(x)))) == ((w | g) | f)
+
+
+# Applicative laws
+def test_writer_applicative_identity():
+    v = Writer(5, ["v"])
+    assert (Writer.pure(lambda x: x) @ v) == v
+
+
+def test_writer_applicative_homomorphism():
+    f = lambda x: x + 1
+    x = 3
+    left = Writer.pure(f) @ Writer.pure(x)
+    right = Writer.pure(f(x))
+    assert left == right
+
+
+def test_writer_applicative_interchange():
+    u = Writer.pure(lambda x: x * 2)
+    y = 7
+    left = u @ Writer.pure(y)
+    right = Writer.pure(lambda f: f(y)) @ u
+    assert left == right
+
+
+# Monad laws
+def test_writer_monad_left_identity():
+    f = lambda x: Writer(x + 1, ["f"])
+    x = 5
+    assert Writer.pure(x).bind(f) == f(x)
+
+
+def test_writer_monad_right_identity():
+    m = Writer(4, ["m"])
+    assert m.bind(Writer.pure) == m
+
+
+def test_writer_monad_associativity():
+    m = Writer(1, ["m"])
+    f = lambda x: Writer(x + 1, ["f"])
+    g = lambda y: Writer(y * 2, ["g"])
+    assert m.bind(f).bind(g) == m.bind(lambda x: f(x).bind(g))

--- a/tests/test_writer_t.py
+++ b/tests/test_writer_t.py
@@ -1,5 +1,6 @@
 from darkcore.writer_t import WriterT
 from darkcore.result import Ok, Err
+import pytest
 
 def test_writer_t_lift_and_run():
     wt = WriterT.lift(Ok(42), [])
@@ -26,3 +27,60 @@ def test_writer_t_composition():
         return WriterT(Ok((f"val={x}", ["fmt"])))
     prog = WriterT(Ok((5, ["start"]))) >> step1 >> step2
     assert prog.run == Ok(("val=6", ["start", "inc", "fmt"]))
+
+
+# Functor laws
+def test_writer_t_functor_identity():
+    w = WriterT(Ok((3, ["log"])))
+    assert w.fmap(lambda a: a).run == w.run
+
+
+def test_writer_t_functor_composition():
+    w = WriterT(Ok((2, ["log"])))
+    f = lambda x: x + 1
+    g = lambda x: x * 2
+    assert w.fmap(lambda x: f(g(x))).run == w.fmap(g).fmap(f).run
+
+
+# Applicative laws
+def test_writer_t_applicative_identity():
+    v = WriterT(Ok((5, ["v"])))
+    pure_id = WriterT(Ok((lambda x: x, [])))
+    assert pure_id.ap(v).run == v.run
+
+
+def test_writer_t_applicative_homomorphism():
+    f = lambda x: x + 1
+    x = 3
+    left = WriterT(Ok((f, []))).ap(WriterT(Ok((x, []))))
+    right = WriterT(Ok((f(x), [])))
+    assert left.run == right.run
+
+
+def test_writer_t_applicative_interchange():
+    u = WriterT(Ok((lambda x: x * 2, ["f"])))
+    y = 7
+    left = u.ap(WriterT(Ok((y, []))))
+    right = WriterT(Ok((lambda f: f(y), []))).ap(u)
+    assert left.run == right.run
+
+
+# Monad laws
+def test_writer_t_monad_left_identity():
+    f = lambda x: WriterT(Ok((x + 1, ["f"])))
+    x = 5
+    assert WriterT(Ok((x, []))).bind(f).run == f(x).run
+
+
+def test_writer_t_monad_right_identity():
+    m = WriterT(Ok((4, ["m"])))
+    assert m.bind(lambda a: WriterT(Ok((a, [])))).run == m.run
+
+
+def test_writer_t_monad_associativity():
+    m = WriterT(Ok((1, ["m"])))
+    f = lambda x: WriterT(Ok((x + 1, ["f"])))
+    g = lambda y: WriterT(Ok((y * 2, ["g"])))
+    left = m.bind(f).bind(g).run
+    right = m.bind(lambda x: f(x).bind(g)).run
+    assert left == right

--- a/tests/test_writer_t.py
+++ b/tests/test_writer_t.py
@@ -1,17 +1,20 @@
+import pytest
 from darkcore.writer_t import WriterT
 from darkcore.result import Ok, Err
-import pytest
+
+
+def wt_list(value, log=None):
+    return WriterT(Ok((value, log if log is not None else [])))
+
+
+def wt_str(value, log=None):
+    return WriterT(Ok((value, log if log is not None else "")), combine=str.__add__)
+
 
 def test_writer_t_lift_and_run():
     wt = WriterT.lift(Ok(42), [])
     assert wt.run == Ok((42, []))
 
-def test_writer_t_basic_bind():
-    w1 = WriterT(Ok((3, ["init"])))
-    def step(x: int) -> WriterT[int, str]:
-        return WriterT(Ok((str(x), ["to-str"])))
-    w2 = w1 >> step
-    assert w2.run == Ok(("3", ["init", "to-str"]))
 
 def test_writer_t_err_propagates():
     wt = WriterT(Err("fail"))
@@ -20,67 +23,88 @@ def test_writer_t_err_propagates():
     res = wt >> step
     assert res.run == Err("fail")
 
-def test_writer_t_composition():
-    def step1(x: int) -> WriterT[int, int]:
-        return WriterT(Ok((x+1, ["inc"])))
-    def step2(x: int) -> WriterT[int, str]:
-        return WriterT(Ok((f"val={x}", ["fmt"])))
-    prog = WriterT(Ok((5, ["start"]))) >> step1 >> step2
-    assert prog.run == Ok(("val=6", ["start", "inc", "fmt"]))
-
-
 # Functor laws
-def test_writer_t_functor_identity():
-    w = WriterT(Ok((3, ["log"])))
+@pytest.mark.parametrize("factory,log", [
+    (wt_list, ["log"]),
+    (wt_str, "log"),
+])
+def test_writer_t_functor_identity(factory, log):
+    w = factory(3, log)
     assert w.fmap(lambda a: a).run == w.run
 
 
-def test_writer_t_functor_composition():
-    w = WriterT(Ok((2, ["log"])))
+@pytest.mark.parametrize("factory,log", [
+    (wt_list, ["log"]),
+    (wt_str, "log"),
+])
+def test_writer_t_functor_composition(factory, log):
+    w = factory(2, log)
     f = lambda x: x + 1
     g = lambda x: x * 2
     assert w.fmap(lambda x: f(g(x))).run == w.fmap(g).fmap(f).run
 
-
 # Applicative laws
-def test_writer_t_applicative_identity():
-    v = WriterT(Ok((5, ["v"])))
-    pure_id = WriterT(Ok((lambda x: x, [])))
+@pytest.mark.parametrize("factory,log", [
+    (wt_list, ["v"]),
+    (wt_str, "v"),
+])
+def test_writer_t_applicative_identity(factory, log):
+    v = factory(5, log)
+    pure_id = factory(lambda x: x)
     assert pure_id.ap(v).run == v.run
 
 
-def test_writer_t_applicative_homomorphism():
+@pytest.mark.parametrize("factory,log", [
+    (wt_list, None),
+    (wt_str, None),
+])
+def test_writer_t_applicative_homomorphism(factory, log):
     f = lambda x: x + 1
     x = 3
-    left = WriterT(Ok((f, []))).ap(WriterT(Ok((x, []))))
-    right = WriterT(Ok((f(x), [])))
+    left = factory(f).ap(factory(x))
+    right = factory(f(x))
     assert left.run == right.run
 
 
-def test_writer_t_applicative_interchange():
-    u = WriterT(Ok((lambda x: x * 2, ["f"])))
+@pytest.mark.parametrize("factory,log", [
+    (wt_list, None),
+    (wt_str, None),
+])
+def test_writer_t_applicative_interchange(factory, log):
+    u = factory(lambda x: x * 2)
     y = 7
-    left = u.ap(WriterT(Ok((y, []))))
-    right = WriterT(Ok((lambda f: f(y), []))).ap(u)
+    left = u.ap(factory(y))
+    right = factory(lambda f: f(y)).ap(u)
     assert left.run == right.run
-
 
 # Monad laws
-def test_writer_t_monad_left_identity():
-    f = lambda x: WriterT(Ok((x + 1, ["f"])))
+@pytest.mark.parametrize("factory,log", [
+    (wt_list, None),
+    (wt_str, None),
+])
+def test_writer_t_monad_left_identity(factory, log):
+    f = lambda x: factory(x + 1)
     x = 5
-    assert WriterT(Ok((x, []))).bind(f).run == f(x).run
+    assert factory(x).bind(f).run == f(x).run
 
 
-def test_writer_t_monad_right_identity():
-    m = WriterT(Ok((4, ["m"])))
-    assert m.bind(lambda a: WriterT(Ok((a, [])))).run == m.run
+@pytest.mark.parametrize("factory,log", [
+    (wt_list, ["m"]),
+    (wt_str, "m"),
+])
+def test_writer_t_monad_right_identity(factory, log):
+    m = factory(4, log)
+    assert m.bind(lambda a: factory(a)).run == m.run
 
 
-def test_writer_t_monad_associativity():
-    m = WriterT(Ok((1, ["m"])))
-    f = lambda x: WriterT(Ok((x + 1, ["f"])))
-    g = lambda y: WriterT(Ok((y * 2, ["g"])))
+@pytest.mark.parametrize("factory,log", [
+    (wt_list, None),
+    (wt_str, None),
+])
+def test_writer_t_monad_associativity(factory, log):
+    m = factory(1)
+    f = lambda x: factory(x + 1)
+    g = lambda y: factory(y * 2)
     left = m.bind(f).bind(g).run
     right = m.bind(lambda x: f(x).bind(g)).run
     assert left == right


### PR DESCRIPTION
## Summary
- add `MonadOpsMixin` supplying `|`, `>>`, `@` operators
- implement `ap` for Reader, State, Writer and support generic logs
- document ResultT and updated Writer usage
- fix mypy warnings and restrict type-checking to `darkcore`

## Testing
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8a9720c14832fa49323e9f0b74efb