### PR TITLE
Clarify ReaderT/StateT equality semantics

### DIFF
--- a/darkcore/reader_t.py
+++ b/darkcore/reader_t.py
@@ -52,3 +52,13 @@ class ReaderT(Generic[R, A]):
 
     def __repr__(self) -> str:
         return f"ReaderT({self.run!r})"
+
+    def __eq__(self, other: object) -> bool:
+        """Structural equality for ``ReaderT`` is undefined.
+
+        ``ReaderT`` wraps a function ``R -> m a``; comparing these function
+        objects directly would yield identity-based results rather than
+        extensional equality.  Tests should compare outputs of ``run`` with the
+        same environment instead.
+        """
+        return NotImplemented

--- a/darkcore/state_t.py
+++ b/darkcore/state_t.py
@@ -69,3 +69,12 @@ class StateT(Generic[S, A]):
 
     def __repr__(self) -> str:
         return f"StateT({self.run!r})"
+
+    def __eq__(self, other: object) -> bool:
+        """Structural equality for ``StateT`` is undefined.
+
+        ``StateT`` wraps ``S -> m (a, S)`` functions. Comparing them directly
+        would only check object identity.  Tests should compare the results of
+        ``run`` for the same initial state instead.
+        """
+        return NotImplemented

--- a/tests/test_reader_t.py
+++ b/tests/test_reader_t.py
@@ -37,6 +37,13 @@ def test_reader_t_composition():
     assert res == Ok("user=alice, val=8")
 
 
+def test_reader_t_extensional_equality():
+    r1 = ReaderT(lambda env: Ok(env["x"] + 1))
+    r2 = ReaderT(lambda env: Ok(env["x"] + 1))
+    env = {"x": 2}
+    assert r1.run(env) == r2.run(env)
+
+
 # Functor laws
 @pytest.mark.parametrize("env", [{"x": 1}, {"x": 2}])
 def test_reader_t_functor_identity(env):

--- a/tests/test_state_t.py
+++ b/tests/test_state_t.py
@@ -32,6 +32,12 @@ def test_state_t_composition():
     assert result == Ok(("val=6, state=6", 12))
 
 
+def test_state_t_extensional_equality():
+    s1 = StateT(lambda s: Ok((s + 1, s)))
+    s2 = StateT(lambda s: Ok((s + 1, s)))
+    assert s1.run(2) == s2.run(2)
+
+
 # Functor laws
 @pytest.mark.parametrize("s", [0, 1])
 def test_state_t_functor_identity(s):


### PR DESCRIPTION
## Summary
- make ReaderT and StateT equality explicit by returning `NotImplemented`
- add notes explaining extensional comparison and corresponding tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b66e8e90832fa673d63651aa61b4