### PR TITLE
Enforce monoid config for Writer and expand law tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,15 @@ w = Writer.pure(3).tell(["start"]) >> (lambda x: Writer(x + 1, ["inc"]))
 print(w)  # Writer(4, log=['start', 'inc'])
 
 # for non-``list`` logs, pass ``empty`` and ``combine`` explicitly
+# ``empty`` provides the identity element and ``combine`` appends logs
 w2 = Writer("hi", empty=str, combine=str.__add__).tell("!")
 print(w2)  # Writer('hi', log='!')
+
+# omitting these for a non-``list`` log raises ``TypeError``
+try:
+    Writer("hi", "!")  # missing empty/combine
+except TypeError:
+    print("expected TypeError")
 ```
 
 ---

--- a/darkcore/writer.py
+++ b/darkcore/writer.py
@@ -24,16 +24,16 @@ class Writer(MonadOpsMixin[A], Generic[A, W]):
     ) -> None:
         self.value = value
 
-        if combine is None or empty is None:
-            if combine is None and empty is None and (
-                log is None or isinstance(log, list)
-            ):
+        if combine is None and empty is None:
+            if log is None or isinstance(log, list):
                 combine = cast(Callable[[W, W], W], lambda a, b: a + b)
                 empty = cast(Callable[[], W], list)
             else:
                 raise TypeError(
                     "Writer for non-list logs requires explicit 'combine' and 'empty'"
                 )
+        elif combine is None or empty is None:
+            raise TypeError("Writer requires both 'combine' and 'empty'")
 
         assert combine is not None and empty is not None
         self.combine = combine

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -63,6 +63,17 @@ def test_writer_applicative_interchange(factory):
     right = factory(lambda f: f(y)) @ u
     assert left == right
 
+
+@pytest.mark.parametrize("factory", [writer_list, writer_str])
+def test_writer_applicative_composition(factory):
+    compose = lambda f: lambda g: lambda x: f(g(x))
+    u = factory(lambda x: x + 1)
+    v = factory(lambda x: x * 2)
+    w = factory(3)
+    left = factory(compose) @ u @ v @ w
+    right = u @ (v @ w)
+    assert left == right
+
 # Monad laws
 @pytest.mark.parametrize("factory", [writer_list, writer_str])
 def test_writer_monad_left_identity(factory):

--- a/tests/test_writer_t.py
+++ b/tests/test_writer_t.py
@@ -77,6 +77,20 @@ def test_writer_t_applicative_interchange(factory, log):
     right = factory(lambda f: f(y)).ap(u)
     assert left.run == right.run
 
+
+@pytest.mark.parametrize("factory,log", [
+    (wt_list, None),
+    (wt_str, None),
+])
+def test_writer_t_applicative_composition(factory, log):
+    compose = lambda f: lambda g: lambda x: f(g(x))
+    u = factory(lambda x: x + 1)
+    v = factory(lambda x: x * 2)
+    w = factory(3)
+    left = factory(compose).ap(u).ap(v).ap(w)
+    right = u.ap(v.ap(w))
+    assert left.run == right.run
+
 # Monad laws
 @pytest.mark.parametrize("factory,log", [
     (wt_list, None),


### PR DESCRIPTION
## Summary
- enforce explicit `empty`/`combine` when Writer is used with non-list logs
- document Writer usage for list and non-list monoids in README
- add Applicative composition law tests for Writer and WriterT

## Testing
- `python -m mypy --strict`
- `pytest -v --cov=darkcore`

Closes #3, Closes #4

------
https://chatgpt.com/codex/tasks/task_e_68a8bd1bd6f0832fac8d265794210230