### PR TITLE
Enable Python pattern matching for core types

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,43 @@ mx = Maybe(4)
 print((mf @ mx) | (lambda x: x + 1))  # Just(9)
 ```
 
+### Pattern Matching
+
+```python
+from darkcore.result import Ok, Err
+from darkcore.maybe import Maybe
+from darkcore.either import Right, Left
+from darkcore.writer import Writer
+
+def classify(r):
+    match r:
+        case Ok(v) if v > 10:
+            return ("big", v)
+        case Ok(v):
+            return ("ok", v)
+        case Err(e):
+            return ("err", e)
+
+def maybe_demo(m):
+    match m:
+        case Maybe(value=None):
+            return "nothing"
+        case Maybe(value=v):
+            return v
+
+def either_demo(x):
+    match x:
+        case Right(v):
+            return v
+        case Left(e):
+            return e
+
+w = Writer(3, ["a"], empty=list, combine=lambda a, b: a + b)
+match w:
+    case Writer(v, log=ls):
+        print(v, ls)
+```
+
 ---
 
 ## 📖 Integration Example

--- a/darkcore/either.py
+++ b/darkcore/either.py
@@ -19,8 +19,14 @@ class Either(MonadOpsMixin[A], Monad[A], Generic[A]):
 
 
 class Left(Either[A]):
+    __match_args__ = ("error",)
+
     def __init__(self, value: A) -> None:
         self.value = value
+
+    @property
+    def error(self) -> A:
+        return self.value
 
     @classmethod
     def pure(cls, value: A) -> "Either[A]":
@@ -41,6 +47,8 @@ class Left(Either[A]):
 
 
 class Right(Either[A]):
+    __match_args__ = ("value",)
+
     def __init__(self, value: A) -> None:
         self.value = value
 

--- a/darkcore/maybe.py
+++ b/darkcore/maybe.py
@@ -7,6 +7,7 @@ B = TypeVar("B")
 
 class Maybe(MonadOpsMixin[A], Generic[A]):
     __slots__ = ("_value",)
+    __match_args__ = ("value",)
 
     def __init__(self, value: Optional[A]) -> None:
         self._value = value
@@ -48,3 +49,7 @@ class Maybe(MonadOpsMixin[A], Generic[A]):
 
     def __repr__(self) -> str:
         return "Nothing" if self._value is None else f"Just({self._value!r})"
+
+    @property
+    def value(self) -> Optional[A]:
+        return self._value

--- a/darkcore/result.py
+++ b/darkcore/result.py
@@ -24,6 +24,7 @@ class Result(MonadOpsMixin[A], Monad[A], Generic[A]):
         return isinstance(other, Result) and self.__dict__ == other.__dict__
 
 class Ok(Result[A]):
+    __match_args__ = ("value",)
     def __init__(self, value: A) -> None:
         self.value = value
 
@@ -50,6 +51,7 @@ class Ok(Result[A]):
 
 
 class Err(Result[A]):
+    __match_args__ = ("error",)
     def __init__(self, error: str) -> None:
         self.error = error
 

--- a/darkcore/writer.py
+++ b/darkcore/writer.py
@@ -13,6 +13,7 @@ class Writer(MonadOpsMixin[A], Generic[A, W]):
     ログ型 ``W`` はモノイドを想定し、デフォルトでは ``list`` を用いる。
     ``combine`` を差し替えることで他のモノイドにも対応できる。
     """
+    __match_args__ = ("value", "log")
 
     def __init__(
         self,

--- a/tests/test_match_either.py
+++ b/tests/test_match_either.py
@@ -1,0 +1,11 @@
+from darkcore.either import Right, Left
+
+def test_match_either():
+    def handle(x):
+        match x:
+            case Right(v):
+                return ("right", v)
+            case Left(e):
+                return ("left", e)
+    assert handle(Right(7)) == ("right", 7)
+    assert handle(Left("e")) == ("left", "e")

--- a/tests/test_match_maybe.py
+++ b/tests/test_match_maybe.py
@@ -1,0 +1,14 @@
+from darkcore.maybe import Maybe
+
+def test_match_maybe_value_none():
+    def handle(m):
+        match m:
+            case Maybe(value=None):
+                return "nothing"
+            case Maybe(value=v) if v % 2:
+                return ("odd", v)
+            case Maybe(value=v):
+                return ("even", v)
+    assert handle(Maybe(None)) == "nothing"
+    assert handle(Maybe(3)) == ("odd", 3)
+    assert handle(Maybe(4)) == ("even", 4)

--- a/tests/test_match_result.py
+++ b/tests/test_match_result.py
@@ -1,0 +1,14 @@
+from darkcore.result import Ok, Err
+
+def test_match_result_ok_err():
+    def handle(r):
+        match r:
+            case Ok(v) if v > 10:
+                return ("ok-big", v)
+            case Ok(v):
+                return ("ok", v)
+            case Err(e):
+                return ("err", e)
+    assert handle(Ok(5)) == ("ok", 5)
+    assert handle(Ok(42)) == ("ok-big", 42)
+    assert handle(Err("x")) == ("err", "x")

--- a/tests/test_match_writer.py
+++ b/tests/test_match_writer.py
@@ -1,0 +1,9 @@
+from darkcore.writer import Writer
+
+def test_match_writer():
+    w = Writer(3, ["a"], empty=list, combine=lambda a, b: a + b)
+    match w:
+        case Writer(v, log=ls):
+            assert v == 3 and ls == ["a"]
+        case _:
+            assert False, "unreachable"


### PR DESCRIPTION
## Summary
- expose `__match_args__` for Ok/Err, Maybe, Either and Writer
- add read-only aliases for Maybe.value and Left.error
- document and test structural pattern matching examples

## Testing
- `PYTHONPATH=. pytest -v --cov=darkcore`
- `mypy --strict darkcore`


------
https://chatgpt.com/codex/tasks/task_e_68a8c9fdf6e8832fbf82e8c8db0e180f